### PR TITLE
Switch google/btree to use degree 32 like cznic/b

### DIFF
--- a/bench/google-btree/google-btree_test.go
+++ b/bench/google-btree/google-btree_test.go
@@ -13,7 +13,7 @@ func (a googItem) Less(b btree.Item) bool {
 	return a.Key < b.(googItem).Key
 }
 
-const btreeDegree = 2
+const btreeDegree = 32
 
 func BenchmarkInsert(b *testing.B) {
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
cznic/b uses a built-in degree of 32 (https://github.com/cznic/b/blob/master/btree.go#L67).  Switch google/btree benchmark to also use degree-32 for a more similar comparison.
